### PR TITLE
Add Fye ecommerce CMS with Firebase logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,17 @@
-# 100-days-of-Java
+# Fye CBD Ecommerce CMS
 
-## Django Ecommerce CMS
-
-This repository contains a sample ecommerce CMS implemented with Django.
-
-The app provides CRUD functionality for products, a search form, and a small chatbot for basic assistance. It uses SQLite by default so it runs without additional setup.
+Fye is a small sample ecommerce CMS for a CBD business. It is built with **Django**, uses **SQLite** for local storage, and can optionally log chat messages to **Firebase**.  The CMS lets you manage your product catalog and includes a very simple chatbot example.
 
 Run migrations and start the server with:
 
 ```bash
+pip install django firebase-admin
 python manage.py migrate
 python manage.py runserver
 ```
 
 Then visit `http://localhost:8000/products/` to manage products and chat with the bot.
+
+### Firebase Setup
+
+If you want chat logs written to Firebase, create a service account JSON file and place it at `django-app/firebase_credentials.json`.  The app uses `firebase_admin` to write chat transcripts to the `chat_logs` collection.

--- a/django-app/shop/products/templates/products/products.html
+++ b/django-app/shop/products/templates/products/products.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>Products</title>
+    <title>Fye CBD Products</title>
     <script>
         async function sendChat() {
             const message = document.getElementById('chat-input').value;
@@ -16,7 +16,8 @@
     </script>
 </head>
 <body>
-<h1>Products</h1>
+<h1>Fye CBD Products</h1>
+<p>Your simple ecommerce CMS for CBD items.</p>
 <form method="get">
     <input type="text" name="q" placeholder="Search" value="{{ request.GET.q }}"/>
     <button type="submit">Search</button>

--- a/django-app/shop/products/views.py
+++ b/django-app/shop/products/views.py
@@ -1,7 +1,22 @@
+import os
+from django.conf import settings
 from django.shortcuts import render, redirect, get_object_or_404
 from django.http import JsonResponse
 from .models import Product
 from .forms import ProductForm
+
+# Optional Firebase setup for chat logging
+try:
+    import firebase_admin
+    from firebase_admin import credentials, firestore
+
+    cred_path = settings.FIREBASE_CREDENTIALS
+    if os.path.exists(cred_path) and not firebase_admin._apps:
+        cred = credentials.Certificate(cred_path)
+        firebase_admin.initialize_app(cred)
+    firebase_db = firestore.client()
+except Exception:
+    firebase_db = None
 
 
 def product_list(request):
@@ -35,5 +50,10 @@ def chat(request):
             reply = 'Hi from ChatBot!'
         else:
             reply = "I don't understand."
+        if firebase_db:
+            try:
+                firebase_db.collection('chat_logs').add({'message': message, 'reply': reply})
+            except Exception:
+                pass
         return JsonResponse({'response': reply})
     return JsonResponse({'response': 'Send a POST request.'})

--- a/django-app/shop/settings.py
+++ b/django-app/shop/settings.py
@@ -63,3 +63,6 @@ USE_TZ = True
 STATIC_URL = '/static/'
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+# Path to optional Firebase service account
+FIREBASE_CREDENTIALS = BASE_DIR / 'firebase_credentials.json'


### PR DESCRIPTION
## Summary
- rename README and document Fye CBD ecommerce CMS
- integrate optional Firebase chat logging using firebase-admin
- expose Firebase credentials path in settings
- update product template to mention Fye brand

## Testing
- `python -m py_compile django-app/shop/products/views.py django-app/shop/settings.py`
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686ca0f10f2c832cb9d67685b83eaefd